### PR TITLE
Fix Cython version in Android build workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade Cython wheel build
+          pip uninstall -y Cython || true
+          pip install "Cython<3.0.0"
+          pip install --upgrade wheel build
           pip install "buildozer==1.5.0"
           # p4a ставим из GitHub, чтобы не зависеть от отсутствующих релизов на PyPI
           pip install "python-for-android @ git+https://github.com/kivy/python-for-android@develop"


### PR DESCRIPTION
## Summary
- uninstall any preinstalled Cython and pin Cython<3.0.0 during the CI build
- ensure build dependencies still install required tools for Buildozer and python-for-android

## Testing
- not run (workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ee52491248325b07bc7b08ec7df82)