### PR TITLE
Fix Android CI Cython pin and harden AEAD test key KDF

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -27,12 +27,11 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip uninstall -y Cython || true
-          pip install "Cython<3.0.0"
-          pip install --upgrade wheel build
-          pip install "buildozer==1.5.0"
+          python -m pip uninstall -y Cython || true
+          python -m pip install "Cython<3.0.0" wheel build
+          python -m pip install "buildozer==1.5.0"
           # p4a ставим из GitHub, чтобы не зависеть от отсутствующих релизов на PyPI
-          pip install "python-for-android @ git+https://github.com/kivy/python-for-android@develop"
+          python -m pip install "python-for-android @ git+https://github.com/kivy/python-for-android@develop"
           sudo apt-get update
           sudo apt-get install -y pkg-config libffi-dev
 

--- a/tests/test_aead.py
+++ b/tests/test_aead.py
@@ -1,0 +1,34 @@
+"""Tests for AEAD helper utilities."""
+from __future__ import annotations
+
+from hashlib import pbkdf2_hmac
+
+DEFAULT_KEY_LENGTH = 32
+
+
+# Helper to derive a test key (not real KDF, just for tests)
+def generate_test_key(password: bytes, salt: bytes) -> bytes:
+    return pbkdf2_hmac(
+        "sha256",
+        password,
+        salt,
+        100_000,
+        dklen=DEFAULT_KEY_LENGTH,
+    )
+
+
+def test_generate_test_key_length():
+    key = generate_test_key(b"password", b"salt")
+    assert len(key) == DEFAULT_KEY_LENGTH
+
+
+def test_generate_test_key_salt_variation():
+    key1 = generate_test_key(b"password", b"salt1")
+    key2 = generate_test_key(b"password", b"salt2")
+    assert key1 != key2
+
+
+def test_generate_test_key_password_variation():
+    key1 = generate_test_key(b"password1", b"salt")
+    key2 = generate_test_key(b"password2", b"salt")
+    assert key1 != key2


### PR DESCRIPTION
## Summary
- ensure the Android APK workflow installs a single Cython<3.0.0 alongside buildozer and python-for-android
- switch the AEAD test key helper to pbkdf2_hmac and cover it with basic tests

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ee8991ca08325be1b5b808ceb00d0)