### PR TITLE
Fix build-apk workflow dependencies and update test key derivation

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -27,13 +27,14 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip uninstall -y Cython || true
-          python -m pip install "Cython<3.0.0" wheel build
-          python -m pip install "buildozer==1.5.0"
-          # p4a ставим из GitHub, чтобы не зависеть от отсутствующих релизов на PyPI
-          python -m pip install "python-for-android @ git+https://github.com/kivy/python-for-android@develop"
+          python -m pip install --force-reinstall "Cython==0.29.36"
+          python -m pip install wheel build
+          python -m pip install "buildozer==1.5.0" "python-for-android==2024.1.21"
           sudo apt-get update
           sudo apt-get install -y pkg-config libffi-dev
+
+      - name: Show Cython version
+        run: python -c "import Cython; print(Cython.__version__)"
 
       - name: Install Android SDK cmdline-tools
         env:

--- a/tests/test_aead.py
+++ b/tests/test_aead.py
@@ -8,6 +8,8 @@ DEFAULT_KEY_LENGTH = 32
 
 # Helper to derive a test key (not real KDF, just for tests)
 def generate_test_key(password: bytes, salt: bytes) -> bytes:
+    """Derive a deterministic test key using a robust KDF."""
+
     return pbkdf2_hmac(
         "sha256",
         password,


### PR DESCRIPTION
## Summary
- pin Cython 0.29.36 and install stable buildozer/python-for-android in the Android APK workflow
- add a diagnostic step to show the installed Cython version before building
- document the PBKDF2-based test key derivation helper

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'crypto_core')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eedcfa39883259216ca99863779d3)