### PR TITLE
Fix Android build workflow dependencies

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -27,14 +27,18 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --force-reinstall "Cython==0.29.36"
-          python -m pip install wheel build
-          python -m pip install "buildozer==1.5.0" "python-for-android==2024.1.21"
+          pip uninstall -y Cython || true
+          pip install --force-reinstall "Cython==0.29.36" wheel build
+          pip install "buildozer==1.5.0" "python-for-android==2024.1.21"
+          pip install "cryptography==3.4.7" "argon2-cffi==21.3.0" "setuptools-rust"
           sudo apt-get update
-          sudo apt-get install -y pkg-config libffi-dev
+          sudo apt-get install -y build-essential libssl-dev libffi-dev pkg-config rustc cargo
 
-      - name: Show Cython version
-        run: python -c "import Cython; print(Cython.__version__)"
+      - name: Show build tool versions
+        run: |
+          python -c "import Cython; print('Cython', Cython.__version__)"
+          python -c "import setuptools_rust; print('setuptools-rust', setuptools_rust.__version__)"
+          python -c "import cryptography; print('cryptography', cryptography.__version__)"
 
       - name: Install Android SDK cmdline-tools
         env:


### PR DESCRIPTION
## Summary
- ensure the workflow reinstalls Cython alongside buildozer and python-for-android in a controlled order
- install setuptools-rust, cryptography/argon2 build prerequisites, and the necessary system packages including Rust
- add a diagnostic step to print the versions of the critical Python build tools

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef2dbbac08325886bdd9e3cc20cc1)