### PR TITLE
Add setuptools-rust dependency to Android build

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -6,7 +6,7 @@ source.dir = .
 source.include_exts = py,png,jpg,kv,atlas,ttf,otf,txt,md,json
 version = 0.1.0
 
-requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cryptography==3.4.7,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
+requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cryptography==3.4.7,setuptools-rust,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
 bootstrap = sdl2
 
 # важный фикс: только android.archs


### PR DESCRIPTION
## Summary
- add setuptools-rust to the buildozer requirements so python-for-android installs it for cryptography builds

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef72615288325859a2f9bb6dc227d)