### PR TITLE
Pin cryptography build to 3.4.7 using local p4a recipe

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -6,7 +6,7 @@ source.dir = .
 source.include_exts = py,png,jpg,kv,atlas,ttf,otf,txt,md,json
 version = 0.1.0
 
-requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cryptography==3.4.7,setuptools-rust,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
+requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cryptography==3.4.7,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
 bootstrap = sdl2
 
 # важный фикс: только android.archs
@@ -17,6 +17,8 @@ android.minapi = 24
 
 # согласованный ndk api
 p4a.ndk_api = 24
+# локальные рецепты python-for-android с фиксами зависимостей
+p4a.local_recipes = ./p4a-recipes
 # при желании зафиксировать NDK:
 # android.ndk = 25.2.9519653
 

--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -1,0 +1,13 @@
+from pythonforandroid.recipe import CffiRecipe
+
+
+class CryptographyRecipe(CffiRecipe):
+    version = "3.4.7"
+    url = (
+        "https://files.pythonhosted.org/packages/3c/a9/50e54f9b89e0ee1d3f3f94a639a6a39"
+        "aea66e68132c0aaf645ed90e2990b/cryptography-3.4.7.tar.gz"
+    )
+    depends = ["openssl", "setuptools", "cffi"]
+
+
+recipe = CryptographyRecipe()


### PR DESCRIPTION
## Summary
- add a local python-for-android cryptography recipe pinned to 3.4.7 without rust dependencies
- configure buildozer to consume the local recipe and drop the setuptools-rust requirement

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0276486c8325afdddccdb987f6f0)