### PR TITLE
Add compatibility fallbacks for cryptography recipe import

### DIFF
--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -1,4 +1,10 @@
-from pythonforandroid.recipe import CffiRecipe
+try:
+    from pythonforandroid.recipe import CffiRecipe
+except ImportError:  # pragma: no cover - fallback for newer p4a
+    try:
+        from pythonforandroid.recipe import PyprojectRecipe as CffiRecipe
+    except ImportError:  # pragma: no cover - final fallback
+        from pythonforandroid.recipe import PythonRecipe as CffiRecipe
 
 
 class CryptographyRecipe(CffiRecipe):


### PR DESCRIPTION
## Summary
- make the custom cryptography recipe compatible with newer python-for-android releases by trying alternative base classes when CffiRecipe is missing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0b44b2908325828c274cb5e0fb69)