### PR TITLE
Fix cryptography recipe download URL

### DIFF
--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -9,10 +9,11 @@ except ImportError:  # pragma: no cover - fallback for newer p4a
 
 class CryptographyRecipe(CffiRecipe):
     version = "3.4.7"
-    url = (
-        "https://files.pythonhosted.org/packages/3c/a9/50e54f9b89e0ee1d3f3f94a639a6a39"
-        "aea66e68132c0aaf645ed90e2990b/cryptography-3.4.7.tar.gz"
-    )
+    # The previously pinned wheel URL used a hashed PyPI storage path which is
+    # no longer available (404).  Using the canonical ``packages/source`` path
+    # keeps the recipe resilient to future storage migrations on PyPI while
+    # still referencing the exact same release archive.
+    url = "https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-3.4.7.tar.gz"
     depends = ["openssl", "setuptools", "cffi"]
 
 


### PR DESCRIPTION
## Summary
- update the local cryptography recipe to use the canonical source archive URL
- document why the hashed PyPI storage URL was replaced

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0efa68508325bf6007f2336dcd00)