### PR TITLE
Run ensurepip before building cryptography recipe

### DIFF
--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -6,6 +6,8 @@ except ImportError:  # pragma: no cover - fallback for newer p4a
     except ImportError:  # pragma: no cover - final fallback
         from pythonforandroid.recipe import PythonRecipe as CffiRecipe
 
+from pythonforandroid.logger import shprint
+
 
 class CryptographyRecipe(CffiRecipe):
     version = "3.4.7"
@@ -15,6 +17,15 @@ class CryptographyRecipe(CffiRecipe):
     # still referencing the exact same release archive.
     url = "https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-3.4.7.tar.gz"
     depends = ["openssl", "setuptools", "cffi"]
+
+    def prebuild_arch(self, arch):
+        super().prebuild_arch(arch)
+
+        hostpython = getattr(self.ctx, "hostpython", None)
+        if hostpython is None:
+            return
+
+        shprint(hostpython, "-m", "ensurepip", "--upgrade")
 
 
 recipe = CryptographyRecipe()


### PR DESCRIPTION
## Summary
- run ensurepip with the hostpython during the cryptography recipe build to ensure setuptools is installed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f11f4452c8325a9bdaecb2ef06f96)