### PR TITLE
Ensure setuptools is available for cryptography recipe

### DIFF
--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -25,7 +25,25 @@ class CryptographyRecipe(CffiRecipe):
         if hostpython is None:
             return
 
+        # ``ensurepip`` is not guaranteed to install ``setuptools`` when
+        # python-for-android builds the hostpython.  In GitHub Actions the
+        # resulting environment was missing ``setuptools`` which caused the
+        # cryptography recipe installation to abort with ``ModuleNotFoundError``.
+        #
+        # First bootstrap ``pip`` (if possible) and then ensure that
+        # ``setuptools`` and ``wheel`` are available to satisfy
+        # ``setup.py``-based packages such as ``cryptography``.
         shprint(hostpython, "-m", "ensurepip", "--upgrade")
+        shprint(
+            hostpython,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+            "setuptools",
+            "wheel",
+        )
 
 
 recipe = CryptographyRecipe()


### PR DESCRIPTION
## Summary
- ensure the custom cryptography recipe bootstraps pip before installing
- explicitly install pip, setuptools and wheel so setup.py based builds succeed

## Testing
- python -m compileall p4a-recipes/cryptography/__init__.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f15f67c188325ae750b70f8251ac8)