### PR TITLE
Fix cryptography recipe bootstrap and simplify CI deps

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -24,21 +24,17 @@ jobs:
           distribution: temurin
           java-version: "17"
 
-      - name: Install build dependencies
+      - name: Install build deps
         run: |
-          python -m pip install --upgrade pip
-          pip uninstall -y Cython || true
-          pip install --force-reinstall "Cython==0.29.36" wheel build
-          pip install "buildozer==1.5.0" "python-for-android==2024.1.21"
-          pip install "cryptography==3.4.7" "argon2-cffi==21.3.0" "setuptools-rust"
-          sudo apt-get update
-          sudo apt-get install -y build-essential libssl-dev libffi-dev pkg-config rustc cargo
+          python -m pip install --upgrade pip wheel setuptools
+
+      - name: Install buildozer tooling
+        run: |
+          python -m pip install "Cython==0.29.36" "buildozer==1.5.0" "python-for-android==2024.1.21"
 
       - name: Show build tool versions
         run: |
-          python -c "import Cython; print('Cython', Cython.__version__)"
-          python -c "import setuptools_rust; print('setuptools-rust', setuptools_rust.__version__)"
-          python -c "import cryptography; print('cryptography', cryptography.__version__)"
+          python -m pip show buildozer python-for-android Cython
 
       - name: Install Android SDK cmdline-tools
         env:

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -6,7 +6,7 @@ source.dir = .
 source.include_exts = py,png,jpg,kv,atlas,ttf,otf,txt,md,json
 version = 0.1.0
 
-requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cryptography==3.4.7,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
+requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cffi,cryptography==3.4.7,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
 bootstrap = sdl2
 
 # важный фикс: только android.archs

--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -1,49 +1,54 @@
-try:
-    from pythonforandroid.recipe import CffiRecipe
-except ImportError:  # pragma: no cover - fallback for newer p4a
-    try:
-        from pythonforandroid.recipe import PyprojectRecipe as CffiRecipe
-    except ImportError:  # pragma: no cover - final fallback
-        from pythonforandroid.recipe import PythonRecipe as CffiRecipe
-
+from pythonforandroid.recipe import PythonRecipe
 from pythonforandroid.logger import shprint
+from pythonforandroid.toolchain import current_directory
+import sh
 
 
-class CryptographyRecipe(CffiRecipe):
+class CryptographyRecipe(PythonRecipe):
+    # версия без Rust
     version = "3.4.7"
-    # The previously pinned wheel URL used a hashed PyPI storage path which is
-    # no longer available (404).  Using the canonical ``packages/source`` path
-    # keeps the recipe resilient to future storage migrations on PyPI while
-    # still referencing the exact same release archive.
-    url = "https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-3.4.7.tar.gz"
-    depends = ["openssl", "setuptools", "cffi"]
+    url = "https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-{version}.tar.gz"
 
-    def prebuild_arch(self, arch):
-        super().prebuild_arch(arch)
+    # зависимости времени сборки/линковки
+    depends = ["openssl", "cffi", "setuptools", "six", "pycparser"]
 
-        hostpython = getattr(self.ctx, "hostpython", None)
-        if hostpython is None:
-            return
+    # p4a по умолчанию зовёт `setup.py install`. Нам нужно заранее
+    # убедиться, что в hostpython есть pip/setuptools/wheel.
+    def install_python_package(self, arch):
+        env = self.get_recipe_env(arch)
+        hostpython = self.get_hostpython(arch)
 
-        # ``ensurepip`` is not guaranteed to install ``setuptools`` when
-        # python-for-android builds the hostpython.  In GitHub Actions the
-        # resulting environment was missing ``setuptools`` which caused the
-        # cryptography recipe installation to abort with ``ModuleNotFoundError``.
-        #
-        # First bootstrap ``pip`` (if possible) and then ensure that
-        # ``setuptools`` and ``wheel`` are available to satisfy
-        # ``setup.py``-based packages such as ``cryptography``.
-        shprint(hostpython, "-m", "ensurepip", "--upgrade")
+        # 1) bootstrap pip для hostpython (некоторые сборки идут без pip)
+        try:
+            shprint(hostpython, "-m", "ensurepip", _env=env)
+        except sh.ErrorReturnCode:
+            # ignore: если уже установлен
+            pass
+
+        # 2) обновить pip + поставить setuptools/wheel в hostpython
         shprint(
             hostpython,
             "-m",
             "pip",
             "install",
-            "--upgrade",
+            "-U",
             "pip",
             "setuptools",
             "wheel",
+            _env=env,
         )
+
+        # 3) стандартная установка пакета (в таргетный site-packages)
+        with current_directory(self.get_build_dir(arch.arch)):
+            shprint(
+                hostpython,
+                "setup.py",
+                "install",
+                "-O2",
+                "--root=" + self.ctx.get_site_packages_dir(arch),
+                "--install-lib=.",
+                _env=env,
+            )
 
 
 recipe = CryptographyRecipe()


### PR DESCRIPTION
## Summary
- rewrite the local cryptography recipe to bootstrap pip/setuptools in hostpython before installing
- declare cffi in the Buildozer requirements and keep using the local recipes directory
- simplify the GitHub Actions workflow to only upgrade core pip tooling and install buildozer/python-for-android without rust extras

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1a0428088325b992afc3abc12aba)