### PR TITLE
Update cryptography recipe to use modern hostpython API

### DIFF
--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -20,7 +20,8 @@ class CryptographyRecipe(PythonRecipe):
             shprint(hostpython, '-m', 'ensurepip', '--upgrade', _env=env)
         except sh.ErrorReturnCode:
             pass
-        shprint(hostpython, '-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools', 'wheel', _env=env)
+        shprint(hostpython, '-m', 'pip', 'install', '--upgrade', 'pip', _env=env)
+        shprint(hostpython, '-m', 'pip', 'install', 'setuptools', 'wheel', _env=env)
 
         build_dir = self.get_build_dir(arch.arch)
         site_packages = self.ctx.get_site_packages_dir(arch)

--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -16,7 +16,7 @@ class CryptographyRecipe(PythonRecipe):
     # убедиться, что в hostpython есть pip/setuptools/wheel.
     def install_python_package(self, arch):
         env = self.get_recipe_env(arch)
-        hostpython = self.get_hostpython(arch)
+        hostpython = sh.Command(self.ctx.hostpython)
 
         # 1) bootstrap pip для hostpython (некоторые сборки идут без pip)
         try:
@@ -39,13 +39,15 @@ class CryptographyRecipe(PythonRecipe):
         )
 
         # 3) стандартная установка пакета (в таргетный site-packages)
-        with current_directory(self.get_build_dir(arch.arch)):
-            shprint(
-                hostpython,
+        build_dir = self.get_build_dir(arch.arch)
+        site_packages_dir = self.ctx.get_site_packages_dir(arch)
+
+        with current_directory(build_dir):
+            self.call_hostpython_via_targetpython(
                 "setup.py",
                 "install",
                 "-O2",
-                "--root=" + self.ctx.get_site_packages_dir(arch),
+                f"--root={site_packages_dir}",
                 "--install-lib=.",
                 _env=env,
             )


### PR DESCRIPTION
## Summary
- update the cryptography python-for-android recipe to use ctx.hostpython instead of the removed get_hostpython helper
- run the setup.py install step via call_hostpython_via_targetpython from the build directory with the correct environment

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1fb62f20832591915b87f1967823)