### PR TITLE
Pin cryptography below 3.4 for Android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ android_zilant_app/
 kivy>=2.2.0
 kivymd>=1.2.0
 argon2-cffi>=23.1.0
-cryptography>=42.0.0
+cryptography>=2.8,<3.4
 zilant-prime-core>=0.7.0
 ``` 
 

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -6,7 +6,7 @@ source.dir = .
 source.include_exts = py,png,jpg,kv,atlas,ttf,otf,txt,md,json
 version = 0.1.0
 
-requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cffi,cryptography==3.4.7,git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6
+requirements = python3,kivy==2.2.1,kivymd==1.2.0,argon2_cffi==21.3.0,openssl,cffi,"cryptography<3.4",git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6  # <3.4: p4a bootstrap без Rust
 bootstrap = sdl2
 
 # важный фикс: только android.archs

--- a/p4a-recipes/cryptography/__init__.py
+++ b/p4a-recipes/cryptography/__init__.py
@@ -5,17 +5,17 @@ from pythonforandroid.recipe import PythonRecipe
 
 class CryptographyRecipe(PythonRecipe):
     """
-    Рецепт для библиотеки cryptography 3.4.7 (ветка без Rust) под python-for-android.
+    Рецепт для библиотеки cryptography 3.3.2 (последняя без Rust) под python-for-android.
 
-    В requirements указываем:
-        cryptography==3.4.7
+    В requirements указываем диапазон:
+        "cryptography<3.4"
     """
 
     # имя рецепта должно совпадать с именем пакета в requirements
     name = "cryptography"
 
     # версия, которую собираем
-    version = "3.4.7"
+    version = "3.3.2"
 
     # источник исходников на PyPI
     url = (
@@ -42,7 +42,7 @@ class CryptographyRecipe(PythonRecipe):
         """
         Дополнительно блокируем попытки использовать Rust,
         даже если когда-нибудь включишь более новую версию.
-        Для 3.4.7 это не обязательно, но и не мешает.
+        Для 3.3.2 это не обязательно, но и не мешает.
         """
         env = super().get_recipe_env(arch, **kwargs)
         env["CRYPTOGRAPHY_DONT_BUILD_RUST"] = "1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 kivy>=2.2.0
 kivymd>=1.2.0
 argon2-cffi>=23.1.0
-cryptography>=42.0.0
+cryptography>=2.8,<3.4
 pqcrypto>=0.1.5
 git+https://github.com/QuantumKeyUYU/zilant-prime-core.git@v0.1.6


### PR DESCRIPTION
## Summary
- pin the Android Buildozer requirements to cryptography<3.4 to avoid the Rust-based releases
- align the custom python-for-android recipe with cryptography 3.3.2 and keep the no-Rust guard
- update the documented Python requirements to match the non-Rust cryptography constraint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f457b0ce0832582906dfe3c762c55)