### PR TITLE
Ensure argon2-cffi is installed from PyPI

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -11,6 +11,7 @@ source.include_exts = py,png,jpg,kv,atlas,ttf,otf,txt,md,json
 version = 0.1.0
 
 # ВАЖНО: cryptography закреплена <3.4, иначе потянет Rust на Android
+# Argon2 берём с PyPI, т.к. тег 23.1.0 отсутствует в репозитории GitHub
 requirements = python3,kivy==2.3.0,kivymd==1.2.0,cffi==1.16.0,argon2-cffi==23.1.0,cryptography<3.4,androidstorage4kivy
 
 # Bootstrap


### PR DESCRIPTION
## Summary
- document that argon2-cffi 23.1.0 should be pulled from PyPI because the GitHub tag does not exist

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff0848b388325805b729a548ab6eb)