### PR TITLE
Fix argon2 dependency and purge build caches in CI

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -59,6 +59,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildozer-
 
+      - name: Clean buildozer caches
+        run: |
+          buildozer android clean
+          rm -rf .buildozer/android/platform/build-*
+          rm -rf .buildozer/android/packages
+
       - name: Build debug APK
         env:
           P4A_ndk_api: "24"

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -12,7 +12,7 @@ version = 0.1.0
 
 # ВАЖНО: cryptography закреплена <3.4, иначе потянет Rust на Android
 # Argon2 берём с PyPI, т.к. тег 23.1.0 отсутствует в репозитории GitHub
-requirements = python3,kivy==2.3.0,kivymd==1.2.0,cffi==1.16.0,argon2-cffi==23.1.0,cryptography<3.4,androidstorage4kivy
+requirements = python3,kivy==2.3.0,kivymd==1.2.0,cffi==1.16.0,argon2-cffi==21.3.0,cryptography<3.4,androidstorage4kivy,six==1.16.0,pycparser==2.21
 
 # Bootstrap
 bootstrap = sdl2


### PR DESCRIPTION
## Summary
- pin argon2-cffi to the latest PyPI sdist-friendly release and add direct dependencies for stable builds
- ensure the GitHub Actions job fully cleans buildozer/python-for-android caches before building the debug APK

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff35da4648325987b9b0d2db74112)