### PR TITLE
Adjust Buildozer cache cleanup in CI

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -61,9 +61,15 @@ jobs:
 
       - name: Clean buildozer caches
         run: |
-          buildozer android clean
+          echo "Cleaning Buildozer cache (safe mode)"
+          mkdir -p .buildozer
           rm -rf .buildozer/android/platform/build-*
           rm -rf .buildozer/android/packages
+          rm -rf .buildozer/.gradle
+
+      - name: Update python-for-android platform
+        run: |
+          buildozer android update
 
       - name: Build debug APK
         env:


### PR DESCRIPTION
## Summary
- clean the Buildozer cache without calling `buildozer android clean`
- add a safe cache cleanup message and ensure the cache directory exists
- run `buildozer android update` before building the debug APK

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff5109b348325a5c54421c32829d9)